### PR TITLE
Fix build on Ubuntu 22.04

### DIFF
--- a/Makefiles/Makefile.linux64
+++ b/Makefiles/Makefile.linux64
@@ -1,7 +1,7 @@
 ZLIB_DIR=zlib/linux64
 CUDA_DIR=/usr/local/cuda/lib64
 CFLAGS=-DLINUX -O -Wall -m64
-NVCCFLAGS=-DLINUX -L$(ZLIB_DIR) -L$(CUDA_DIR) -O2 -Xptxas -v -Xcompiler -Wall -m64
+NVCCFLAGS=-DLINUX -L$(ZLIB_DIR) -L$(CUDA_DIR) -O2 -Xptxas -v -Xcompiler -Wall -m64 -std c++11
 NVCC=nvcc
 CXX=g++
 


### PR DESCRIPTION
Without this, I get this error:
```
/usr/include/c++/11/bits/std_function.h:435:145: error: parameter packs not expanded with ‘...’:
  435 |         function(_Functor&& __f)
      |                                                                                                                                                 ^ 
/usr/include/c++/11/bits/std_function.h:435:145: note:         ‘_ArgTypes’
/usr/include/c++/11/bits/std_function.h:530:146: error: parameter packs not expanded with ‘...’:
  530 |         operator=(_Functor&& __f)